### PR TITLE
Create new article feature basics

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -1,28 +1,19 @@
-== README
+Blog App
 
-This README would normally document whatever steps are necessary to get the
-application up and running.
+-Articles
+  -ID
+  -Title
+  -Body
 
-Things you may want to cover:
+-Users
+  -ID
+  -Email
+  -Password
 
-* Ruby version
+-Comments
+  -ID
+  -Body
+  -User_ID
+  -Article_ID
 
-* System dependencies
-
-* Configuration
-
-* Database creation
-
-* Database initialization
-
-* How to run the test suite
-
-* Services (job queues, cache servers, search engines, etc.)
-
-* Deployment instructions
-
-* ...
-
-
-Please feel free to use a different markup language if you do not plan to run
-<tt>rake doc:app</tt>.
+  

--- a/app/assets/javascripts/articles.coffee
+++ b/app/assets/javascripts/articles.coffee
@@ -1,0 +1,3 @@
+# Place all the behaviors and hooks related to the matching controller here.
+# All this logic will automatically be available in application.js.
+# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/app/assets/stylesheets/articles.scss
+++ b/app/assets/stylesheets/articles.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the articles controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -1,0 +1,4 @@
+class ArticlesController < ApplicationController
+  def index
+  end
+end

--- a/app/helpers/articles_helper.rb
+++ b/app/helpers/articles_helper.rb
@@ -1,0 +1,2 @@
+module ArticlesHelper
+end

--- a/app/views/articles/index.html.erb
+++ b/app/views/articles/index.html.erb
@@ -1,0 +1,3 @@
+<h1>Create a new Article</h1>
+
+<%= link_to 'New Article', "" %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,9 +1,11 @@
 Rails.application.routes.draw do
+  get 'articles/index'
+
   # The priority is based upon order of creation: first created -> highest priority.
   # See how all your routes lay out with "rake routes".
 
   # You can have the root of your site routed with "root"
-  # root 'welcome#index'
+  root to: 'articles#index'
 
   # Example of regular route:
   #   get 'products/:id' => 'catalog#view'

--- a/public/lecture_16.html
+++ b/public/lecture_16.html
@@ -1,0 +1,110 @@
+Notice, Under the spec folder we have two helper files. viz rails_helper.rb and spec_helper.rb
+
+So here we are going to create a new directory and thats where we are going to have our tests.
+
+mkdir spec/features
+
+Notice how the features directory got created.
+
+Now within this features directory create a new file and then call it creating_article_spec.rb
+
+To write a feature test there is specific syntax which you need to follow
+
+
+creating_article_spec.rb
+
+require 'rails_helper'
+
+RSpec.feature "Creating Articles" do
+  scenario "A user creates a new article" do
+    visit "/"
+
+    click_link "New Article"
+
+    fill_in "Title", with: "Creating first article"
+    fill_in "Body", with: "Hare sreenivasa"
+    click_button "Create Article"
+
+    expect(page).to have_content("Article has been created")
+    expect(page.current_path).to eq(articles_path)
+  end
+end
+
+
+At this point we wanna run the above test.
+
+Command : rspec :- Runs all the spec tests
+If you wanna run specific test(s) then use the below command:
+
+rspec spec/features/creating_article_spec.rb
+(Here I am specifing one single spec or test to run)
+
+1) Creating Articles A user creates a new article
+     Failure/Error: visit "/"
+     ActionController::RoutingError:
+       No route matches [GET] "/"
+
+
+The first error is because we dont have root route defined in our application.
+So let's fix this by defining a root route
+
+routes.rb
+
+add,
+root to: 'articles#index'
+
+save and run the test again.
+
+ 1) Creating Articles A user creates a new article
+     Failure/Error: visit "/"
+     ActionController::RoutingError:
+       uninitialized constant ArticlesController
+
+This time though we still have the same error with a slight difference. It says Uninitialized constant ArticlesController. It is saying that we need to create Articles Controller because we have specified in the routes that the root is Article's controller Index action.
+
+rails g controller articles index
+
+Now run the test again, (rspec spec/features/creating_article_spec.rb)
+
+ 1) Creating Articles A user creates a new article
+     Failure/Error: click_link "New Article"
+     Capybara::ElementNotFound:
+       Unable to find link "New Article"
+
+Notice how the routing error have disappeared. We haven't implemented this feature so it is saying      Failure/Error: click_link "New Article"
+
+We are going to create this link now. In the app/views/articles/index.html.erb
+
+<h1>Create a new Article</h1>
+
+<%= link_to 'New Article', new_article_path %>
+
+Now re-run this test again,(rspec spec/features/creating_article_spec.rb)
+
+1) Creating Articles A user creates a new article
+     Failure/Error: visit "/"
+     ActionView::Template::Error:
+       undefined local variable or method `new_article_path' for #<#<Class:0x00000000a89080>:0x00000000a9b0c8>
+
+Now it is saying template error and undefined local variable new_article_path because we haven't defined new_article_path yet.
+
+But notice in the spec we have said click 'New Article'. Now it is clicking the link 'New Article' but it is unable to find the route as it is not defined yet.
+
+At this point we can also run the application (rails s) and try to emulate what this feature test is doing. we can do a small hack or cheat by removing the new_article_path in the link_to i.e., something like,
+
+<%= link_to 'New Article', "" %>
+
+So as to make sure that the link New Article is getting clicked.
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/spec/controllers/articles_controller_spec.rb
+++ b/spec/controllers/articles_controller_spec.rb
@@ -1,0 +1,12 @@
+require 'rails_helper'
+
+RSpec.describe ArticlesController, type: :controller do
+
+  describe "GET #index" do
+    it "returns http success" do
+      get :index
+      expect(response).to have_http_status(:success)
+    end
+  end
+
+end

--- a/spec/features/creating_article_spec.rb
+++ b/spec/features/creating_article_spec.rb
@@ -1,0 +1,16 @@
+require 'rails_helper'
+
+RSpec.feature "Creating Articles" do
+  scenario "A user creates a new article" do
+    visit "/"
+
+    click_link "New Article"
+
+    fill_in "Title", with: "Creating first article"
+    fill_in "Body", with: "Hare sreenivasa"
+    click_button "Create Article"
+
+    expect(page).to have_content("Article has been created")
+    expect(page.current_path).to eq(articles_path)
+  end
+end

--- a/spec/helpers/articles_helper_spec.rb
+++ b/spec/helpers/articles_helper_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+# Specs in this file have access to a helper object that includes
+# the ArticlesHelper. For example:
+#
+# describe ArticlesHelper do
+#   describe "string concat" do
+#     it "concats two strings with spaces" do
+#       expect(helper.concat_strings("this","that")).to eq("this that")
+#     end
+#   end
+# end
+RSpec.describe ArticlesHelper, type: :helper do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/views/articles/index.html.erb_spec.rb
+++ b/spec/views/articles/index.html.erb_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe "articles/index.html.erb", type: :view do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
Notice, Under the spec folder we have two helper files. viz rails_helper.rb and spec_helper.rb

So here we are going to create a new directory and thats where we are going to have our tests.

mkdir spec/features

Notice how the features directory got created.

Now within this features directory create a new file and then call it creating_article_spec.rb

To write a feature test there is specific syntax which you need to follow

creating_article_spec.rb

require 'rails_helper'

RSpec.feature "Creating Articles" do
  scenario "A user creates a new article" do
    visit "/"

```
click_link "New Article"

fill_in "Title", with: "Creating first article"
fill_in "Body", with: "Hare sreenivasa"
click_button "Create Article"

expect(page).to have_content("Article has been created")
expect(page.current_path).to eq(articles_path)
```

  end
end

At this point we wanna run the above test.

Command : rspec :- Runs all the spec tests
If you wanna run specific test(s) then use the below command:

rspec spec/features/creating_article_spec.rb
(Here I am specifing one single spec or test to run)

1) Creating Articles A user creates a new article
     Failure/Error: visit "/"
     ActionController::RoutingError:
       No route matches [GET] "/"

The first error is because we dont have root route defined in our application.
So let's fix this by defining a root route

routes.rb

add,
root to: 'articles#index'

save and run the test again.

 1) Creating Articles A user creates a new article
     Failure/Error: visit "/"
     ActionController::RoutingError:
       uninitialized constant ArticlesController

This time though we still have the same error with a slight difference. It says Uninitialized constant ArticlesController. It is saying that we need to create Articles Controller because we have specified in the routes that the root is Article's controller Index action.

rails g controller articles index

Now run the test again, (rspec spec/features/creating_article_spec.rb)

 1) Creating Articles A user creates a new article
     Failure/Error: click_link "New Article"
     Capybara::ElementNotFound:
       Unable to find link "New Article"

Notice how the routing error have disappeared. We haven't implemented this feature so it is saying      Failure/Error: click_link "New Article"

We are going to create this link now. In the app/views/articles/index.html.erb

<h1>Create a new Article</h1>


<%= link_to 'New Article', new_article_path %>

Now re-run this test again,(rspec spec/features/creating_article_spec.rb)

1) Creating Articles A user creates a new article
     Failure/Error: visit "/"
     ActionView::Template::Error:
       undefined local variable or method `new_article_path' for #<#Class:0x00000000a89080:0x00000000a9b0c8>

Now it is saying template error and undefined local variable new_article_path because we haven't defined new_article_path yet.

But notice in the spec we have said click 'New Article'. Now it is clicking the link 'New Article' but it is unable to find the route as it is not defined yet.

At this point we can also run the application (rails s) and try to emulate what this feature test is doing. we can do a small hack or cheat by removing the new_article_path in the link_to i.e., something like,

<%= link_to 'New Article', "" %>

So as to make sure that the link New Article is getting clicked.
