### PR TITLE
changed to flash.now in the else part

### DIFF
--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -13,7 +13,7 @@ class ArticlesController < ApplicationController
       flash[:success] = "Article has been created."
       redirect_to articles_path
     else
-      flash[:danger] = "Article has not been created"
+      flash.now[:danger] = "Article has not been created"
       render :new
     end
   end


### PR DESCRIPTION
flash versus flash.now
In the controller create action we had used flash in both the if else condition. The issue was when the article creation gets failed, we can see the flash messages but when we move on to some other window, the flash messaged stays there and if we refresh or again go to some other window, the message goes off. This is not the expected behavior in the else part (failure of article creation). So we use flash.now so that the flash message goes off whenever we switch to a different window.
However, the above behavior ( behavior of flash) holds fine in the case of success as when the article gets successfully created we are redirecting the user with the flash message of success to a different page.
